### PR TITLE
DOC: fix typo

### DIFF
--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -190,7 +190,7 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         the options allowed by :func:`sklearn.metrics.pairwise_distances` for
         its metric parameter.
         If metric is "precomputed", X is assumed to be a distance matrix and
-        must be square. X may be a :term:`Glossary <sparse graph>`, in which
+        must be square. X may be a :term:`sparse graph`, in which
         case only "nonzero" elements may be considered neighbors for DBSCAN.
 
         .. versionadded:: 0.17


### PR DESCRIPTION
Just a small typo fix for the name of a link in the documentation of DBSCAN.

Changed "X may be a [Glossary](https://scikit-learn.org/stable/glossary.html#term-sparse-graph), in which ..." to "X may be a [sparse graph](https://scikit-learn.org/stable/glossary.html#term-sparse-graph), in which ..."